### PR TITLE
fix: improve compatibility with busybox

### DIFF
--- a/src/c8y-command
+++ b/src/c8y-command
@@ -28,7 +28,7 @@ SHELL_BIN=
 # Load settings file
 SETTINGS_FILE=/etc/c8y-command-plugin/env
 if [ -f "$SETTINGS_FILE" ]; then
-    FOUND_FILE=$(find "$SETTINGS_FILE" -perm 644 | head -1)
+    FOUND_FILE=$(find "$SETTINGS_FILE" -perm 644 | head -n1)
 
     if [ -n "$FOUND_FILE" ]; then
         info "Loading settings: $FOUND_FILE"


### PR DESCRIPTION
Busybox is used in Yocto and does not support the head -1 syntax