### PR TITLE
fix: use date ref which is compatible with busybox 1.35

### DIFF
--- a/src/c8y-command
+++ b/src/c8y-command
@@ -2,7 +2,7 @@
 set -e
 
 info() {
-    echo "$(date --iso-8601=seconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z 2>/dev/null) INFO $*" >&2
+    echo "$(date --iso-8601=seconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z 2>/dev/null ||:) INFO $*" >&2
 }
 
 info "Received message: $*"

--- a/src/c8y-command
+++ b/src/c8y-command
@@ -2,7 +2,7 @@
 set -e
 
 info() {
-    echo "$(date --iso-8601=seconds 2>/dev/null || date -Iseconds) INFO $*" >&2
+    echo "$(date --iso-8601=seconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z 2>/dev/null) INFO $*" >&2
 }
 
 info "Received message: $*"


### PR DESCRIPTION
The default version of busybox used in Yocto kirkstone (busybox 1.35) does not support the `date -I` option. Instead use an explicit date format string which should be compatible everywhere, and also mute any stderr from the date command if it is not compatible.